### PR TITLE
NOJIRA pull pip packages from artifactory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,6 @@ WORKDIR /account-links-generator
 COPY requirements.txt .
 
 # Install python dependencies
-RUN pip install --no-cache-dir -r requirements.txt
+RUN pip install --index-url https://artefacts.tax.service.gov.uk/artifactory/api/pypi/pips/simple --no-cache-dir -r requirements.txt
 
 COPY . .


### PR DESCRIPTION
## What
- Use artifactory for pip packages

## Why
- https://confluence.tools.tax.service.gov.uk/pages/viewpage.action?spaceKey=TEC&postingDay=2023%2F4%2F11&title=%5BACTION+REQUIRED%5D+HTTP+Egress+on+Build+Jenkins+will+be+blocked+on+the+9th+May+2023